### PR TITLE
NERF can be TianoCore free

### DIFF
--- a/index.md
+++ b/index.md
@@ -89,7 +89,7 @@ Boot time comparison on Lenovo ThinkPad X230. yabits vs default UEFI
 | yabits    | ✔️          | ✔️         | ✔️           | ✔️              |
 | default   | ✖️          | ✖️         | ✖️           | ✖️              |
 | TianoCore | ✖️          | ✖️         | ✔️           | ✖️              |
-| NERF      | ✔️          | ✔️         | ✔️           | ✖️              |
+| NERF      | ✔️          | ✔️         | ✔️           | ✔️              |
 
 ## License
 


### PR DESCRIPTION
NERF can be a coreboot payload without any Tianocore involved.